### PR TITLE
Add Expansion Enum

### DIFF
--- a/src/main/java/com/alvarx4z/woja/domain/Expansion.java
+++ b/src/main/java/com/alvarx4z/woja/domain/Expansion.java
@@ -1,0 +1,43 @@
+package com.alvarx4z.woja.domain;
+
+import com.alvarx4z.woja.domain.shared.Name;
+
+import java.util.UUID;
+
+import static java.util.UUID.randomUUID;
+
+public enum Expansion {
+
+    VANILLA(randomUUID(), Order.of(1), Name.of("Vanilla")),
+    BURNING_CRUSADE(randomUUID(), Order.of(2), Name.of("The Burning Crusade")),
+    WRATH_LICH_KING(randomUUID(), Order.of(3), Name.of("Wrath of the Lich King")),
+    CATACLYSM(randomUUID(), Order.of(4), Name.of("Cataclysm")),
+    MISTS_PANDARIA(randomUUID(), Order.of(5), Name.of("Mists of Pandaria")),
+    WARLORDS_DRAENOR(randomUUID(), Order.of(6), Name.of("Warlords of Draenor")),
+    LEGION(randomUUID(), Order.of(7), Name.of("Legion")),
+    BATTLE_FOR_AZEROTH(randomUUID(), Order.of(8), Name.of("Battle for Azeroth")),
+    SHADOWLANDS(randomUUID(), Order.of(9), Name.of("Shadowlands")),
+    DRAGONFLIGHT(randomUUID(), Order.of(10), Name.of("Dragonflight"));
+
+    private final UUID id;
+    private final Order order;
+    private final Name title;
+
+    Expansion(UUID id, Order order, Name title) {
+        this.id = id;
+        this.order = order;
+        this.title = title;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public Order getOrder() {
+        return order;
+    }
+
+    public Name getTitle() {
+        return title;
+    }
+}

--- a/src/test/java/com/alvarx4z/woja/domain/ExpansionTest.java
+++ b/src/test/java/com/alvarx4z/woja/domain/ExpansionTest.java
@@ -1,0 +1,42 @@
+package com.alvarx4z.woja.domain;
+
+import com.alvarx4z.woja.domain.shared.Name;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class ExpansionTest {
+
+    @Test
+    @DisplayName("Should contain valid data in the Expansion Enum")
+    void givenExpansions_whenCheckingProperties_thenAreValid() {
+        Expansion expansion = Expansion.valueOf(Expansion.VANILLA.toString());
+
+        assertThat(expansion).isInstanceOf(Expansion.class);
+        assertThat(expansion.getId()).isInstanceOf(UUID.class);
+        assertThat(expansion.getOrder()).isEqualTo(Expansion.VANILLA.getOrder());
+        assertThat(expansion.getTitle()).isInstanceOf(Name.class);
+        assertThat(expansion.getTitle().getValue()).isEqualTo(Expansion.VANILLA.getTitle().getValue());
+    }
+
+    @Test
+    @DisplayName("Should there be a total of 10 Expansions")
+    void givenExpansions_whenCheckingAmountExpansions_thenReturn10() {
+        int numberOfExpansions = Expansion.values().length;
+
+        assertThat(numberOfExpansions).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("Should throw IllegalArgumentException when Expansion doesn't exist")
+    void givenNonExistingExpansion_whenChecking_thenThrowIllegalArgumentException() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> Expansion.valueOf("FAKE")
+        );
+    }
+}


### PR DESCRIPTION
# Goal

To add an `Expansion` Enum that represents each of the released WoW Expansions.

# Implementation

- The Enum itself.
- Unit Tests.

# Further considerations

Pending to add a `Year` property which states the released year of the expansion.

# Checklist

- [ ] I created or expanded the project's documentation.
- [X] I added or expanded the tests for new features and enhancements.
- [X] I applied the same coding conventions as in the rest of the project.
