### PR TITLE
Add Year to Expansion

### DIFF
--- a/src/main/java/com/alvarx4z/woja/domain/Expansion.java
+++ b/src/main/java/com/alvarx4z/woja/domain/Expansion.java
@@ -2,31 +2,34 @@ package com.alvarx4z.woja.domain;
 
 import com.alvarx4z.woja.domain.shared.Name;
 
+import java.time.Year;
 import java.util.UUID;
 
 import static java.util.UUID.randomUUID;
 
 public enum Expansion {
 
-    VANILLA(randomUUID(), Order.of(1), Name.of("Vanilla")),
-    BURNING_CRUSADE(randomUUID(), Order.of(2), Name.of("The Burning Crusade")),
-    WRATH_LICH_KING(randomUUID(), Order.of(3), Name.of("Wrath of the Lich King")),
-    CATACLYSM(randomUUID(), Order.of(4), Name.of("Cataclysm")),
-    MISTS_PANDARIA(randomUUID(), Order.of(5), Name.of("Mists of Pandaria")),
-    WARLORDS_DRAENOR(randomUUID(), Order.of(6), Name.of("Warlords of Draenor")),
-    LEGION(randomUUID(), Order.of(7), Name.of("Legion")),
-    BATTLE_FOR_AZEROTH(randomUUID(), Order.of(8), Name.of("Battle for Azeroth")),
-    SHADOWLANDS(randomUUID(), Order.of(9), Name.of("Shadowlands")),
-    DRAGONFLIGHT(randomUUID(), Order.of(10), Name.of("Dragonflight"));
+    VANILLA(randomUUID(), Order.of(1), Name.of("Vanilla"), Year.of(2004)),
+    BURNING_CRUSADE(randomUUID(), Order.of(2), Name.of("The Burning Crusade"), Year.of(2007)),
+    WRATH_LICH_KING(randomUUID(), Order.of(3), Name.of("Wrath of the Lich King"), Year.of(2008)),
+    CATACLYSM(randomUUID(), Order.of(4), Name.of("Cataclysm"), Year.of(2010)),
+    MISTS_PANDARIA(randomUUID(), Order.of(5), Name.of("Mists of Pandaria"), Year.of(2012)),
+    WARLORDS_DRAENOR(randomUUID(), Order.of(6), Name.of("Warlords of Draenor"), Year.of(2014)),
+    LEGION(randomUUID(), Order.of(7), Name.of("Legion"), Year.of(2016)),
+    BATTLE_FOR_AZEROTH(randomUUID(), Order.of(8), Name.of("Battle for Azeroth"), Year.of(2018)),
+    SHADOWLANDS(randomUUID(), Order.of(9), Name.of("Shadowlands"), Year.of(2020)),
+    DRAGONFLIGHT(randomUUID(), Order.of(10), Name.of("Dragonflight"), Year.of(2022));
 
     private final UUID id;
     private final Order order;
     private final Name title;
+    private final Year year;
 
-    Expansion(UUID id, Order order, Name title) {
+    Expansion(UUID id, Order order, Name title, Year year) {
         this.id = id;
         this.order = order;
         this.title = title;
+        this.year = year;
     }
 
     public UUID getId() {
@@ -39,5 +42,9 @@ public enum Expansion {
 
     public Name getTitle() {
         return title;
+    }
+
+    public Year getYear() {
+        return year;
     }
 }

--- a/src/main/java/com/alvarx4z/woja/domain/Expansion.java
+++ b/src/main/java/com/alvarx4z/woja/domain/Expansion.java
@@ -9,16 +9,66 @@ import static java.util.UUID.randomUUID;
 
 public enum Expansion {
 
-    VANILLA(randomUUID(), Order.of(1), Name.of("Vanilla"), Year.of(2004)),
-    BURNING_CRUSADE(randomUUID(), Order.of(2), Name.of("The Burning Crusade"), Year.of(2007)),
-    WRATH_LICH_KING(randomUUID(), Order.of(3), Name.of("Wrath of the Lich King"), Year.of(2008)),
-    CATACLYSM(randomUUID(), Order.of(4), Name.of("Cataclysm"), Year.of(2010)),
-    MISTS_PANDARIA(randomUUID(), Order.of(5), Name.of("Mists of Pandaria"), Year.of(2012)),
-    WARLORDS_DRAENOR(randomUUID(), Order.of(6), Name.of("Warlords of Draenor"), Year.of(2014)),
-    LEGION(randomUUID(), Order.of(7), Name.of("Legion"), Year.of(2016)),
-    BATTLE_FOR_AZEROTH(randomUUID(), Order.of(8), Name.of("Battle for Azeroth"), Year.of(2018)),
-    SHADOWLANDS(randomUUID(), Order.of(9), Name.of("Shadowlands"), Year.of(2020)),
-    DRAGONFLIGHT(randomUUID(), Order.of(10), Name.of("Dragonflight"), Year.of(2022));
+    VANILLA(
+        randomUUID(),
+        Order.of(1),
+        Name.of("Vanilla"),
+        Year.of(2004)
+    ),
+    BURNING_CRUSADE(
+        randomUUID(),
+        Order.of(2),
+        Name.of("The Burning Crusade"),
+        Year.of(2007)
+    ),
+    WRATH_LICH_KING(
+        randomUUID(),
+        Order.of(3),
+        Name.of("Wrath of the Lich King"), Year
+        .of(2008)
+    ),
+    CATACLYSM(
+        randomUUID(),
+        Order.of(4),
+        Name.of("Cataclysm"),
+        Year.of(2010)
+    ),
+    MISTS_PANDARIA(
+        randomUUID(),
+        Order.of(5),
+        Name.of("Mists of Pandaria"),
+        Year.of(2012)
+    ),
+    WARLORDS_DRAENOR(
+        randomUUID(),
+        Order.of(6),
+        Name.of("Warlords of Draenor"),
+        Year.of(2014)
+    ),
+    LEGION(
+        randomUUID(),
+        Order.of(7),
+        Name.of("Legion"),
+        Year.of(2016)
+    ),
+    BATTLE_FOR_AZEROTH(
+        randomUUID(),
+        Order.of(8),
+        Name.of("Battle for Azeroth"),
+        Year.of(2018)
+    ),
+    SHADOWLANDS(
+        randomUUID(),
+        Order.of(9),
+        Name.of("Shadowlands"),
+        Year.of(2020)
+    ),
+    DRAGONFLIGHT(
+        randomUUID(),
+        Order.of(10),
+        Name.of("Dragonflight"),
+        Year.of(2022)
+    );
 
     private final UUID id;
     private final Order order;

--- a/src/test/java/com/alvarx4z/woja/domain/ExpansionTest.java
+++ b/src/test/java/com/alvarx4z/woja/domain/ExpansionTest.java
@@ -4,8 +4,11 @@ import com.alvarx4z.woja.domain.shared.Name;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.Year;
+import java.util.Arrays;
 import java.util.UUID;
 
+import static com.alvarx4z.woja.domain.Expansion.VANILLA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -14,13 +17,15 @@ final class ExpansionTest {
     @Test
     @DisplayName("Should contain valid data in the Expansion Enum")
     void givenExpansions_whenCheckingProperties_thenAreValid() {
-        Expansion expansion = Expansion.valueOf(Expansion.VANILLA.toString());
+        Expansion expansion = Expansion.valueOf(VANILLA.toString());
 
         assertThat(expansion).isInstanceOf(Expansion.class);
         assertThat(expansion.getId()).isInstanceOf(UUID.class);
-        assertThat(expansion.getOrder()).isEqualTo(Expansion.VANILLA.getOrder());
+        assertThat(expansion.getOrder()).isEqualTo(VANILLA.getOrder());
         assertThat(expansion.getTitle()).isInstanceOf(Name.class);
-        assertThat(expansion.getTitle().getValue()).isEqualTo(Expansion.VANILLA.getTitle().getValue());
+        assertThat(expansion.getTitle().getValue()).isEqualTo(VANILLA.getTitle().getValue());
+        assertThat(expansion.getYear()).isInstanceOf(Year.class);
+        assertThat(expansion.getYear().getValue()).isEqualTo(VANILLA.getYear().getValue());
     }
 
     @Test
@@ -29,6 +34,17 @@ final class ExpansionTest {
         int numberOfExpansions = Expansion.values().length;
 
         assertThat(numberOfExpansions).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("Should be all the Expansions' Year from 2004 onwards")
+    void givenExpansions_whenCheckingYears_thenAreValid() {
+        boolean result =
+            Arrays
+                .stream(Expansion.values())
+                .allMatch(exp -> exp.getYear().isAfter(Year.of(VANILLA.getYear().getValue() - 1)));
+
+        assertThat(result).isTrue();
     }
 
     @Test

--- a/src/test/java/com/alvarx4z/woja/domain/OrderTest.java
+++ b/src/test/java/com/alvarx4z/woja/domain/OrderTest.java
@@ -10,7 +10,7 @@ final class OrderTest {
 
     @Test
     @DisplayName("Should instantiate correctly an Order")
-    void givenPositiveInteger_whenInstantiating_thenInstantiatesCorrectly() {
+    void givenOrder_whenInstantiating_thenInstantiatesCorrectly() {
         Order order = Order.of(1);
 
         assertThat(order).isInstanceOf(Order.class);
@@ -19,7 +19,7 @@ final class OrderTest {
 
     @Test
     @DisplayName("Should throw IllegalArgumentException when value is 0 or lower")
-    void givenInvalidPositiveInteger_whenInstantiating_thenThrowIllegalArgumentException() {
+    void givenInvalidOrder_whenInstantiating_thenThrowIllegalArgumentException() {
         assertThrows(
             IllegalArgumentException.class,
             () -> Order.of(0)


### PR DESCRIPTION
# Goal

To add the releasing `Year` of each `Expansion`.

# Implementation

- To add `Year` as an `Expansion` property.
- To extend and add Unit Tests.

# Further considerations

Since the `Expansion` Enum will not be stored in the Database, next steps would be creating a Controller and UseCase for retrieving this info via REST API.

# Checklist

- [ ] I created or expanded the project's documentation.
- [X] I added or expanded the tests for new features and enhancements.
- [X] I applied the same coding conventions as in the rest of the project.
